### PR TITLE
deps: use distroless/static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ COPY *.go ./
 RUN go mod download
 RUN CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -a -o /bin/app
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static
 COPY --from=builder /bin/app /bin/app
 ENTRYPOINT ["/bin/app"]


### PR DESCRIPTION
This change can reduce the docker image size to 14.2MB from 32.2MB